### PR TITLE
Jeff: Convert Not_found exception when gethostbyname fails.

### DIFF
--- a/memcache.ml
+++ b/memcache.ml
@@ -57,7 +57,13 @@ type connection = {
 }
 
 let open_connection hostname port =
-  Lwt_lib.gethostbyname hostname >>= fun haddr ->
+  catch
+    (fun () -> Lwt_lib.gethostbyname hostname)
+    (function
+      | Not_found -> raise (Failure ("Cannot resolve host name: " ^ hostname))
+      | e -> raise e
+    )
+  >>= fun haddr ->
   Lwt_io.open_connection (Unix.ADDR_INET (haddr.Unix.h_addr_list.(0), port)) >>= fun (input, output) ->
   return {
     hostname = hostname;


### PR DESCRIPTION
`Not_found` would be raised in case of general network downtime or DNS failures.
